### PR TITLE
Uncaught Exception listener no longer re-registered when require('zombie') fails

### DIFF
--- a/Zombie/ZombieDriver.js
+++ b/Zombie/ZombieDriver.js
@@ -1,9 +1,9 @@
 "use strict";
 
-process.on('uncaughtException', e => console.error('Uncaught Exception: ' + e));
-
 const Zombie = require('zombie');
 const zombie = new Zombie();
+
+process.on('uncaughtException', e => console.error('Uncaught Exception: ' + e));
 
 //  Entry point for Edge.js
 return function(data, callback) {

--- a/Zombie/ZombieDriver.js
+++ b/Zombie/ZombieDriver.js
@@ -3,9 +3,9 @@
 const Zombie = require('zombie');
 const zombie = new Zombie();
 
-process.on('uncaughtException', e => console.error('Uncaught Exception: ' + e));
-
 //  Entry point for Edge.js
 return function(data, callback) {
-  callback(null, new Bridge(zombie));
+    let bridge = new Bridge(zombie);
+    process.on('uncaughtException', e => console.error('Uncaught Exception: ' + e));
+    callback(null, bridge);
 }


### PR DESCRIPTION
Moving the process.on(...) handler to after the require('zombie') so that any failed efforts to initialise zombie doesn't result in re-registering the listener.
